### PR TITLE
Update persona from MLOps to ML Engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Below is a common set of persona definitions that can be used to build out the API specification.
 
-#### MLOps Engineers
+#### ML Engineers
 
     Build and manage deployment pipelines, CI/CD, and monitoring for ML models, ensuring automation and scalability across the model lifecycle.
 


### PR DESCRIPTION
This closes #36 .

MLOps is a practice whereas ML Engineers are roles. Updating this to be more tied to a persona/role.